### PR TITLE
Unsolicited PR #1: Improve Survey Droids!

### DIFF
--- a/MMOCoreORB/src/server/zone/managers/resource/InterplanetarySurveyTask.h
+++ b/MMOCoreORB/src/server/zone/managers/resource/InterplanetarySurveyTask.h
@@ -32,6 +32,8 @@ public:
 		// We need to sort this by family name
 		HashTable<String, Vector<String>* > mapped;
 		HashTable<String, Vector<String>* > typeMap;
+		// Map names to resource attribute strings - could have done with HashTables of HashTables, but let's just do the nasty here.
+		HashTable<String, String> attributeMap;
 		for(int i=0;i<resources.size();i++) {
 			resourceSpawn = resources.get(i);
 			String family = resourceSpawn->getFamilyName();
@@ -58,6 +60,20 @@ public:
 				mlist->add(name);
 				mapped.put(type,mlist);
 			}
+
+			// Map name to attribute string
+			StringBuffer attributeBuffer;
+			int value = -1;
+			String attributeName = "";
+			int attributeIndex = 0;
+			while(value != 0) {
+				value = resourceSpawn->getAttributeAndValue(attributeName, attributeIndex);
+				if (value != 0) {
+					attributeBuffer << "\t\t\t" << attributeName << ": " << value << "\n";
+					attributeIndex++;
+				}
+			}
+			attributeMap.put(name, attributeBuffer.toString());
 		}
 		// Create Email:
 		StringBuffer body;
@@ -101,6 +117,7 @@ public:
 				Vector<String>* values = mapped.get(sType);
 				for(int j=0;j<values->size();j++) {
 					body << "\t\t\\#pcontrast1 " << values->get(j) << "\\#.\n";
+					body << attributeMap.get(values->get(j));
 				}
 			}
 		}

--- a/MMOCoreORB/src/server/zone/objects/player/sessions/InterplanetarySurveyDroidSessionImplementation.cpp
+++ b/MMOCoreORB/src/server/zone/objects/player/sessions/InterplanetarySurveyDroidSessionImplementation.cpp
@@ -179,8 +179,13 @@ void InterplanetarySurveyDroidSessionImplementation::handleMenuSelect(CreatureOb
 
 		ObjectManager::instance()->persistObject(data, 1, "surveys");
 
-		tool->destroyObjectFromWorld(true);
-		tool->destroyObjectFromDatabase(true);
+		// Rather than always using a tool per survey droid, simply damage it.
+		tool->setConditionDamage(tool->getConditionDamage() + 40, true);
+		// If the damage is greater than the remaining condition, trash it.
+		if (tool->isDestroyed()) {
+			tool->destroyObjectFromWorld(true);
+			tool->destroyObjectFromDatabase(true);
+		}
 
 		tangibleObject->decreaseUseCount();
 		cancelSession();


### PR DESCRIPTION
This change set includes two changes:

1. Survey droids no longer directly consume tools. Rather, they damage them. Once the tool is fully damaged, it's destroyed. This change is implemented purely in InterplanetarySurveyDroidSessionImplementation.cpp

2. Survey droid mail reports include resource attributes. This will break compatibility with Galaxy Harvester, if we care - but it does give users a reason to prefer ISDs at all, over just flying to a planet and clicking the tool themselves. This change is implemented purely in InterplanetarySurveyTask.h

Unfortunately, it's pretty tough to get Core3 to link properly with the repo as-is, so this is essentially only checked for syntax errors - it will probably need some love from you on your private TC.